### PR TITLE
feat: add unified login page

### DIFF
--- a/mesthri-frontend/src/App.jsx
+++ b/mesthri-frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Customer from "./pages/Customer";
 import Mestri from "./pages/Mestri";
 import Worker from "./pages/Worker";
 import Search from "./pages/Search";
+import Login from "./pages/Login";
 
 export default function App() {
   return (
@@ -14,6 +15,7 @@ export default function App() {
         <Route path="/mestri" element={<Mestri />} />
         <Route path="/worker" element={<Worker />} />
         <Route path="/search" element={<Search />} />
+        <Route path="/login" element={<Login />} />
         <Route path="*" element={<Home />} />
       </Routes>
     </BrowserRouter>

--- a/mesthri-frontend/src/Components/Navbar.jsx
+++ b/mesthri-frontend/src/Components/Navbar.jsx
@@ -1,11 +1,13 @@
 import { Link, useNavigate } from "react-router-dom";
+import { isLoggedIn, clearCredentials } from "../Services/auth";
 
 export default function Navbar() {
   const navigate = useNavigate();
+  const loggedIn = isLoggedIn();
 
   function logout() {
-    localStorage.removeItem("mesthri_basic");
-    navigate("/customer");
+    clearCredentials();
+    navigate("/login");
   }
 
   const link =
@@ -23,12 +25,21 @@ export default function Navbar() {
           <Link to="/mestri" className={link}>Mestri</Link>
           <Link to="/worker" className={link}>Worker</Link>
         </div>
-        <button
-          onClick={logout}
-          className="bg-white text-indigo-700 font-bold px-3 py-2 rounded-md hover:opacity-90"
-        >
-          Logout
-        </button>
+        {loggedIn ? (
+          <button
+            onClick={logout}
+            className="bg-white text-indigo-700 font-bold px-3 py-2 rounded-md hover:opacity-90"
+          >
+            Logout
+          </button>
+        ) : (
+          <Link
+            to="/login"
+            className="bg-white text-indigo-700 font-bold px-3 py-2 rounded-md hover:opacity-90"
+          >
+            Login
+          </Link>
+        )}
       </div>
     </nav>
   );

--- a/mesthri-frontend/src/pages/Login.jsx
+++ b/mesthri-frontend/src/pages/Login.jsx
@@ -1,10 +1,61 @@
-function Login() {
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Navbar from "../components/Navbar";
+import { login } from "../Services/api";
+import { setBasicCredentials } from "../Services/auth";
+
+export default function Login() {
+  const [phone, setPhone] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+  const navigate = useNavigate();
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setMessage("");
+    try {
+      const data = await login({ phone, password });
+      setBasicCredentials(phone, password);
+      const role = data.role?.toUpperCase();
+      if (role === "MESTHRI") navigate("/mestri");
+      else if (role === "WORKER") navigate("/worker");
+      else navigate("/customer");
+    } catch (err) {
+      setMessage(err.message);
+    }
+  }
+
   return (
-    <div>
-      <h2>Login Page</h2>
-      <p>This is where the login form will go.</p>
+    <div className="min-h-screen bg-rainbow">
+      <Navbar />
+      <div className="flex items-center justify-center min-h-[calc(100vh-64px)] p-4">
+        <form onSubmit={handleSubmit} className="bg-white p-8 rounded-xl shadow-xl w-full max-w-md">
+          <h1 className="text-2xl font-bold mb-6 text-center text-purple-600">Login</h1>
+          <input
+            className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-400"
+            placeholder="Phone"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-400 mt-4"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          {message && <div className="mt-4 text-center text-red-600">{message}</div>}
+          <button
+            type="submit"
+            className="w-full mt-6 bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition"
+          >
+            Sign In
+          </button>
+        </form>
+      </div>
     </div>
   );
 }
 
-export default Login;


### PR DESCRIPTION
## Summary
- add a common login page for customers, mestris, and workers
- wire up route and navigation to reach the new page
- show login or logout in navbar based on auth state

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6896327f66e88327a21d948717674081